### PR TITLE
update dependencies to prevent error on initial import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dependencies = [
+    "colorama >= 0.4.6",
+    "toolz >= 0.12.0",
+]
 
 
 


### PR DESCRIPTION
Initial test of cuallee caused an error as there were missing dependencies, below are the steps to reproduce and the fix for the PR. 

Hope this helps?

### OS:
Windows 10

### Steps to produce error
- Created a new folder
- Created a venv with `python -m venv venv`
- Activated venv with `venv/scripts/activate`
- Install cuallee with `pip install cuallee`
- install pandas with `pip install pandas`
- Created main.py file as follows:

```python
# main.py

import pandas as pd
from cuallee import Check, CheckLevel  # WARN:0, ERR: 1

df = pd.DataFrame(
    {
        "name": ["Raphael", "Donatello"],
        "mask": ["red", "purple"],
        "weapon": ["sai", "bo staff"],
    }
)

# Nulls on column name
check = Check(CheckLevel.WARNING, "Completeness")
test = check.is_complete("name").is_unique("name").validate(df)

print(test)

```

- Run main file with `python main.py`

### Errors
```shell
Traceback (most recent call last):
  File "C:\DQ_bug\main.py", line 11, in <module>
    from cuallee import Check, CheckLevel  # WARN:0, ERR: 1
  File "C:\DQ_bug\venv\lib\site-packages\cuallee\__init__.py", line 13, in <module>
    from colorama import Fore, Style  # type: ignore
ModuleNotFoundError: No module named 'colorama'
```

- installed  'colorama' with `pip install  colorama`
- Run main file with `python main.py`

### Errors
```shell
Traceback (most recent call last):
  File "C:\DQ_bug\main.py", line 11, in <module>
    from cuallee import Check, CheckLevel  # WARN:0, ERR: 1
  File "C:\DQ_bug\venv\lib\site-packages\cuallee\__init__.py", line 14, in <module>
    from toolz import valfilter  # type: ignore
ModuleNotFoundError: No module named 'toolz'
```

- installed  'toolz' with `pip install  toolz`
- Run main file with `python main.py`

### Output:
```shell
   id            timestamp         check    level column  ... rows violations  pass_rate  pass_threshold  status
0   1  2022-11-19 19:09:23  Completeness  WARNING   name  ...    2          0        1.0             1.0    PASS
1   2  2022-11-19 19:09:23  Completeness  WARNING   name  ...    2          0        1.0             1.0    PASS

[2 rows x 12 columns]
```

- Forked repo and updated `pyproject.toml`
- added `dependencies` `"colorama >= 0.4.6",` and `"toolz >= 0.12.0",`
- Version numbers were determined by `pip freeze > requirements.txt`
```text
colorama==0.4.6
cuallee==0.2.2
numpy==1.23.4
pandas==1.5.1
python-dateutil==2.8.2
pytz==2022.6
six==1.16.0
toolz==0.12.0
``` 