### PR TITLE
Update CONTRIBUTING.md, add case-insensitive column matching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to [cuallee](https://github.com/canimus/cuallee)
 
-`cuallee` is open source software. We value feedbacks and we want to make contributing to this project as
+`cuallee` is open source software. We value feedback and we want to make contributing to this project as
 easy and transparent as possible, whether it's:
 
 - Reporting a bug
@@ -8,37 +8,35 @@ easy and transparent as possible, whether it's:
 - Submitting a fix
 - Proposing new features
 
-## We develop with Github
-We use github to host code, to track issues and feature requests, as well as accept pull requests.
+## We develop with GitHub
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 
 ## Submitting code changes
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `main`.
 1. If you've added code that should be tested, add tests.
-1. Unit tests are splitted by library `test/unit/pandas...`, `test/unit/pyspark...`, add your own
+1. Unit tests are split by library `test/unit/pandas...`, `test/unit/pyspark...`, add your own
 1. If you've changed APIs, update the documentation.
-1. We use `black` and `flake8` for linting, which are incorporated in the Github Actions
-1. Issue that pull request and wait for it to be reviewed by a maintainer or contributor!
+1. Issue that pull request and wait for it to be reviewed by a maintainer or contributor! `black` and `flake8` will lint your code automatically via Github Actions
 
-## Report bugs using Github's [issues](https://github.com/canimus/cuallee/issues)
+## Report bugs using GitHub [issues](https://github.com/canimus/cuallee/issues)
 We use GitHub issues to track public bugs. Report a bug by opening a new issue.
 Be aware that regardless of the missleading word `issue`, we use Github issues to track new `features`, `enhancements`, etc.
 So please review the existing list of issues, to make sure your request is not duplicated.
 
 **Great Bug Reports** tend to have:
 
-- A quick summary and/or background
+- A quick summary
 - Steps to reproduce
-  - Your operative system and version
-  - Give sample code if you can
+  - Your operating system and version
   - Ideally a form of the repo, and the branch of your test example
-  - Alternatively a gist were to get the test case
+- Alternatively, [`reprexpy`](https://github.com/crew102/reprexpy) can output a minimally reproducible example
 - What you expected would happen
 - What actually happens
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
 
-## Start a discussion using Github's [discussions](https://github.com/canimus/cuallee/discussions)
+## Start a discussion using GitHub's [discussions](https://github.com/canimus/cuallee/discussions)
 Open or join a discussion on the future or state of `cuallee`
 If you want to propose a new feature, this is the right place to do it! Just start a discussion, and
 let us know why you think this feature would be a good addition to `cuallee` (by possibly including some usage examples).

--- a/cuallee/pandas_validation.py
+++ b/cuallee/pandas_validation.py
@@ -235,7 +235,7 @@ def validate_data_types(rules: List[Rule], dataframe: pd.DataFrame):
 
     # NUMERIC
     # =======
-    numeric_columns = cuallee_utils.get_rule_colums(
+    numeric_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_numeric_rules(rules)
     )
     numeric_dtypes = dataframe.select_dtypes("number")
@@ -244,14 +244,14 @@ def validate_data_types(rules: List[Rule], dataframe: pd.DataFrame):
 
     # DATE
     # =======
-    date_columns = cuallee_utils.get_rule_colums(cuallee_utils.get_date_rules(rules))
+    date_columns = cuallee_utils.get_rule_columns(cuallee_utils.get_date_rules(rules))
     date_dtypes = dataframe.select_dtypes("datetime")
     date_match = cuallee_utils.match_data_types(date_columns, date_dtypes)
     assert not date_match, f"Column(s): {date_match} are not date"
 
     # TIMESTAMP
     # =======
-    timestamp_columns = cuallee_utils.get_rule_colums(
+    timestamp_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_timestamp_rules(rules)
     )
     timestamp_dtypes = dataframe.select_dtypes("datetime64")
@@ -262,7 +262,7 @@ def validate_data_types(rules: List[Rule], dataframe: pd.DataFrame):
 
     # STRING
     # =======
-    string_columns = cuallee_utils.get_rule_colums(
+    string_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_string_rules(rules)
     )
     string_dtypes = dataframe.select_dtypes("object")

--- a/cuallee/polars_validation.py
+++ b/cuallee/polars_validation.py
@@ -325,7 +325,7 @@ def validate_data_types(rules: List[Rule], dataframe: pl.DataFrame):
 
     # # NUMERIC
     # # =======
-    # numeric_columns = cuallee_utils.get_rule_colums(
+    # numeric_columns = cuallee_utils.get_rule_columns(
     #     cuallee_utils.get_numeric_rules(rules)
     # )
     # numeric_dtypes = dataframe.select_dtypes("number")
@@ -334,14 +334,14 @@ def validate_data_types(rules: List[Rule], dataframe: pl.DataFrame):
 
     # # DATE
     # # =======
-    # date_columns = cuallee_utils.get_rule_colums(cuallee_utils.get_date_rules(rules))
+    # date_columns = cuallee_utils.get_rule_columns(cuallee_utils.get_date_rules(rules))
     # date_dtypes = dataframe.select_dtypes("datetime")
     # date_match = cuallee_utils.match_data_types(date_columns, date_dtypes)
     # assert not date_match, f"Column(s): {date_match} are not date"
 
     # # TIMESTAMP
     # # =======
-    # timestamp_columns = cuallee_utils.get_rule_colums(
+    # timestamp_columns = cuallee_utils.get_rule_columns(
     #     cuallee_utils.get_timestamp_rules(rules)
     # )
     # timestamp_dtypes = dataframe.select_dtypes("datetime64")
@@ -352,7 +352,7 @@ def validate_data_types(rules: List[Rule], dataframe: pl.DataFrame):
 
     # # STRING
     # # =======
-    # string_columns = cuallee_utils.get_rule_colums(
+    # string_columns = cuallee_utils.get_rule_columns(
     #     cuallee_utils.get_string_rules(rules)
     # )
     # string_dtypes = dataframe.select_dtypes("object")

--- a/cuallee/pyspark_validation.py
+++ b/cuallee/pyspark_validation.py
@@ -677,12 +677,12 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # COLUMNS
     # =======
-    rule_match = cuallee_utils.match_columns(rules, dataframe.columns)
+    rule_match = cuallee_utils.match_columns(rules, dataframe.columns, case_sensitive = False)
     assert not rule_match, f"Column(s): {rule_match} are not present in dataframe"
 
     # NUMERIC
     # =======
-    numeric_columns = cuallee_utils.get_rule_colums(
+    numeric_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_numeric_rules(rules)
     )
     numeric_dtypes = numeric_fields(dataframe)
@@ -691,14 +691,14 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # DATE
     # =======
-    date_columns = cuallee_utils.get_rule_colums(cuallee_utils.get_date_rules(rules))
+    date_columns = cuallee_utils.get_rule_columns(cuallee_utils.get_date_rules(rules))
     date_dtypes = date_fields(dataframe)
     date_match = cuallee_utils.match_data_types(date_columns, date_dtypes)
     assert not date_match, f"Column(s): {date_match} are not date"
 
     # TIMESTAMP
     # =======
-    timestamp_columns = cuallee_utils.get_rule_colums(
+    timestamp_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_timestamp_rules(rules)
     )
     timestamp_dtypes = timestamp_fields(dataframe)
@@ -709,7 +709,7 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # STRING
     # =======
-    string_columns = cuallee_utils.get_rule_colums(
+    string_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_string_rules(rules)
     )
     string_dtypes = string_fields(dataframe)

--- a/cuallee/snowpark_validation.py
+++ b/cuallee/snowpark_validation.py
@@ -682,7 +682,7 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # NUMERIC
     # =======
-    numeric_columns = cuallee_utils.get_rule_colums(
+    numeric_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_numeric_rules(rules)
     )
     numeric_dtypes = numeric_fields(dataframe)
@@ -691,14 +691,14 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # DATE
     # =======
-    date_columns = cuallee_utils.get_rule_colums(cuallee_utils.get_date_rules(rules))
+    date_columns = cuallee_utils.get_rule_columns(cuallee_utils.get_date_rules(rules))
     date_dtypes = date_fields(dataframe)
     date_match = cuallee_utils.match_data_types(date_columns, date_dtypes)
     assert not date_match, f"Column(s): {date_match} are not date"
 
     # TIMESTAMP
     # =======
-    timestamp_columns = cuallee_utils.get_rule_colums(
+    timestamp_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_timestamp_rules(rules)
     )
     timestamp_dtypes = timestamp_fields(dataframe)
@@ -709,7 +709,7 @@ def validate_data_types(rules: List[Rule], dataframe: DataFrame) -> bool:
 
     # STRING
     # =======
-    string_columns = cuallee_utils.get_rule_colums(
+    string_columns = cuallee_utils.get_rule_columns(
         cuallee_utils.get_string_rules(rules)
     )
     string_dtypes = string_fields(dataframe)

--- a/cuallee/utils.py
+++ b/cuallee/utils.py
@@ -50,11 +50,11 @@ def match_data_types(on_rule: List[str], on_dataframe: List[str]) -> Set[str]:
 
 def match_columns(on_rule: List[Rule], on_dataframe: List[str], case_sensitive: bool = True) -> Set[str]:
     """Confirms all columns in check exists in dataframe"""
+    dataframe_columns = on_dataframe
     rule_columns = set(get_rule_columns(on_rule))
-    if case_sensitive:
-        return rule_columns.difference(on_dataframe)
-    else:
-        rule_columns = {r.casefold(): r for r in rule_columns}
-        dataframe_columns = {c.casefold(): c for c in on_dataframe}
-        return set([rule_columns[i] for i in rule_columns.keys() if i not in dataframe_columns.keys()])
+    if not case_sensitive:
+       rule_columns = map(str.casefold, rule_columns)
+       dataframe_columns = map(str.casefold, on_dataframe)
+    
+    return set(rule_columns).difference(dataframe_columns)
     

--- a/cuallee/utils.py
+++ b/cuallee/utils.py
@@ -38,7 +38,7 @@ def get_string_rules(rules: List[Rule]) -> List[Rule]:
     return list(filter(lambda x: x.data_type.name == CheckDataType.STRING.name, rules))
 
 
-def get_rule_colums(rules: List[Rule]) -> List[str]:
+def get_rule_columns(rules: List[Rule]) -> List[str]:
     """Based on a rule list it returns a flatten set of unique columns"""
     return get_column_set(list(map(lambda x: x.column, rules)))  # type: ignore
 
@@ -48,6 +48,13 @@ def match_data_types(on_rule: List[str], on_dataframe: List[str]) -> Set[str]:
     return set(on_rule).difference(on_dataframe)
 
 
-def match_columns(on_rule: List[Rule], on_dataframe: List[str]) -> Set[str]:
+def match_columns(on_rule: List[Rule], on_dataframe: List[str], case_sensitive: bool = True) -> Set[str]:
     """Confirms all columns in check exists in dataframe"""
-    return set(get_rule_colums(on_rule)).difference(on_dataframe)
+    rule_columns = set(get_rule_columns(on_rule))
+    if case_sensitive:
+        return rule_columns.difference(on_dataframe)
+    else:
+        rule_columns = {r.casefold(): r for r in rule_columns}
+        dataframe_columns = {c.casefold(): c for c in on_dataframe}
+        return set([rule_columns[i] for i in rule_columns.keys() if i not in dataframe_columns.keys()])
+    

--- a/test/unit/pyspark_dataframe/test_spark_validation.py
+++ b/test/unit/pyspark_dataframe/test_spark_validation.py
@@ -145,7 +145,7 @@ def test_validate_columns(spark):
     df = spark.range(10).withColumn("id2", F.col("id").cast("float"))
     check = (
         Check(CheckLevel.WARNING, "test_validate_column_name")
-        .is_complete("id")
+        .is_complete("ID")
         .is_greater_than("id2", 2)
     )
     rs = PSV.validate_data_types(check.rules, df)


### PR DESCRIPTION
## cuallee
- [x] pyspark
- [ ] snowpark
- [ ] pandas
- [ ] duckdb
- [ ] polars
- [x] unit test
- [x] docs
- [ ] other

# Issue this would solve

`cuallee` throws an error when rule names do not match the case of `pyspark` column names. PySpark column identifiers, however, are not case sensitive; thus, current behavior imposes constraints on PySpark behavior. The error is made more confusing by the message, which claims that the column is not present. This PR would introduce case-insensitive column matching to PySpark DataFrames. This PR also includes some small spelling updates.


#  What I did

Added a boolean `case_sensitive` argument to `cuallee_utils.match_columns()`. When `True` (the default), nothing changes from current behavior. When `False`, `match_columns()` would find the case-insensitive difference in column sets. The error message would print the column name in the original case.


# Alternative approaches

* Enforce case sensitivity for all database types. This would eliminate the need for control flow but could confuse newcomers who don't expect case sensitivity. Also, I believe DuckDB is case insensitive, so the function would not be local to 1 database
* Convert PySpark rule column names and DataFrame column names to lowercase (or uppercase) before passing to `match_columns()`. This would be more elegant but would therefore be hidden to other databases for column validation


# How I validated what I did

Changed current test for PySpark to include an uppercase column in the rule specification. Also validated output interactively.


# What I want this review to answer
1. Would passing lowercase rule and dataframe columns to `match_columns()` be preferred?
2. Should a more obvious unit test be added?
