### PR TITLE
fix: summary to use only first 3 characters

### DIFF
--- a/cuallee/pyspark_validation.py
+++ b/cuallee/pyspark_validation.py
@@ -738,7 +738,7 @@ def summary(check: Check, dataframe: DataFrame) -> DataFrame:
 
     # Compute the expression
     computed_expressions = compute(check._rule)
-    if int(spark.version.replace(".", "")) < 330:
+    if int(spark.version.replace(".", "")[:3]) < 330:
         computed_expressions = _replace_observe_compute(computed_expressions)
 
     rows, observation_result = _compute_observe_method(computed_expressions, dataframe)


### PR DESCRIPTION
### Issue to solve

The current implementation for pyspark version check in `cuallee`  checks for version number < 330. However, in some azure/aws environments, the pyspark version can be in the form 3.3.x.x.x.x.x.x, which will exceed the 3 digit constraint.

This PR will ensure that only the first 3 digits, after removal of '.' are captured for version check in pyspark validation

## cuallee
- [Y] pyspark
