### PR TITLE
Transitioned from using the 'lxml' library to utilizing 'xml.etree.ElementTree' for XML parsing.

### DIFF
--- a/cuallee/iso/checks.py
+++ b/cuallee/iso/checks.py
@@ -1,4 +1,4 @@
-from lxml import etree
+import xml.etree.ElementTree as ET
 import requests
 from dataclasses import dataclass
 from typing import List
@@ -23,10 +23,11 @@ def _load_currencies():
     """External download from ISO website of currencies in XML format"""
     DEFAULT_ENDPOINT_4217 = "https://www.six-group.com/dam/download/financial-information/data-center/iso-currrency/lists/list-one.xml"
     response = requests.get(os.getenv("ISO_4217_ENDPOINT", DEFAULT_ENDPOINT_4217))
-    xml = etree.fromstring(response.text.encode("utf-8"))
+    xml = ET.fromstring(response.text.encode("utf-8"))
 
-    def _get_ccy(element: etree._Element) -> Currency:
-        return at("currency")(Currency(*[tag.text for tag in element.getchildren()]))
+    def _get_ccy(element):
+        currency_data = {tag.tag: tag.text for tag in element}
+        return at("currency")(Currency(**currency_data))
 
     return set(filter(None, (map(_get_ccy, xml.xpath("//CcyNtry")))))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "colorama >= 0.4.6",
     "toolz >= 0.12.0",
     "pygments >= 2.15.1",
-    "lxml >= 4.9.2",
     "requests >= 2.28.2",
     "pandas>=1.5.3"
 ]
@@ -50,9 +49,6 @@ duckdb = [
 ]
 polars = [
   "polars>=0.19.6"
-]
-iso = [
-  "lxml >= 4.9.1"
 ]
 test = [
   "pytest",


### PR DESCRIPTION
## cuallee
- [ ] pyspark
- [ ] snowpark
- [ ] pandas
- [ ] duckdb
- [ ] polars
- [ ] unit test
- [ ] docs
- [x] other

It is always challenging to use Cuallee on AWS Glue because installing the 'lxml' library is not straightforward. As Python already includes the 'xml' library, I made a modification to use it instead of relying on the LXML dependency. I hope this contributes to the compatibility of the library across different platforms.
