### PR TITLE
Added `not_contained_in` Function and Alias `not_in` to Expand Cuallee's Validation Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Check | Description | DataType
 `is_equal_than` | `col == x` | _numeric_
 `is_contained_in` | `col in [a, b, c, ...]` | _agnostic_
 `is_in` | Alias of `is_contained_in` | _agnostic_
+`not_contained_in` | `col not in [a, b, c, ...]` | _agnostic_
+`not_in` | Alias of `not_contained_in` | _agnostic_
 `is_between` | `a <= col <= b` | _numeric, date_
 `has_pattern` | Matching a pattern defined as a `regex` | _string_
 `is_legit` | String not null & not empty `^\S$` | _string_

--- a/cuallee/__init__.py
+++ b/cuallee/__init__.py
@@ -362,6 +362,24 @@ class Check:
         Rule("is_between", column, value, CheckDataType.AGNOSTIC, pct) >> self._rule
         return self
 
+    def not_contained_in(
+        self,
+        column: str,
+        value: Union[List, Tuple],
+        pct: float = 1.0,
+    ):
+        """Validation of column value not in set of given values"""
+        (
+            Rule("not_contained_in", column, value, CheckDataType.AGNOSTIC, pct)
+            >> self._rule
+        )
+
+        return self
+    
+    def not_in(self, column: str, value: Tuple[str, int, float], pct: float = 1.0):
+        """Vaidation of column value not in set of given values"""
+        return self.not_contained_in(column, value, pct)
+
     def is_contained_in(
         self,
         column: str,

--- a/cuallee/bigquery_validation.py
+++ b/cuallee/bigquery_validation.py
@@ -73,7 +73,6 @@ class Compute(ComputeEngine):
         )
         return self.compute_instruction
 
-
     def are_unique(self, rule: Rule):
         """Validation for unique values in a group of columns"""
         predicate = None
@@ -89,6 +88,16 @@ class Compute(ComputeEngine):
     def is_contained_in(self, rule: Rule):
         """Validation of column value in set of given values"""
         predicate = f"{rule.column} IN {rule.value}"
+        self.compute_instruction = ComputeInstruction(
+            predicate,
+            self._sum_predicate_to_integer(predicate),
+            ComputeMethod.SQL,
+        )
+        return self.compute_instruction
+
+    def not_contained_in(self, rule: Rule):
+        """Validation of column value not in a set of given values"""
+        predicate = f"{rule.column} NOT IN {rule.value}"
         self.compute_instruction = ComputeInstruction(
             predicate,
             self._sum_predicate_to_integer(predicate),
@@ -135,7 +144,7 @@ def _get_expressions(compute_set: Dict[str, ComputeInstruction]) -> str:
 
 def _build_query(expression_string: str, dataframe: bigquery.table.Table) -> str:
     """Build query final query"""
-    
+
     return f"SELECT {expression_string} FROM `{str(dataframe)}`"
 
 
@@ -190,7 +199,7 @@ def _compute_row(client, dataframe: bigquery.table.Table) -> Dict:
 
 def _calculate_violations(result, nrows) -> Union[int, float]:
     """Return the number of violations for each rule"""
-    
+
     if (result == "true") or (result == True):
         return 0
     elif (result == "false") or (result == False):

--- a/cuallee/duckdb_validation.py
+++ b/cuallee/duckdb_validation.py
@@ -86,6 +86,10 @@ class Compute:
     def is_contained_in(self, rule: Rule) -> str:
         return f"SUM(CAST({rule.column} IN {rule.value} AS INTEGER))"
 
+    def not_contained_in(self, rule: Rule) -> str:
+        """Validation of column value not in a set of given values"""
+        return f"SUM(CAST({rule.column} NOT IN {rule.value} AS INTEGER))"
+
     def has_percentile(self, rule: Rule) -> str:
         return f"QUANTILE_CONT({rule.column}, {rule.settings['percentile']}) = {rule.value}"
 

--- a/cuallee/pandas_validation.py
+++ b/cuallee/pandas_validation.py
@@ -67,7 +67,7 @@ class Compute:
 
     def has_sum(self, rule: Rule, dataframe: pd.DataFrame) -> Union[bool, int]:
         return dataframe.loc[:, rule.column].sum() == rule.value
-    
+
     def has_cardinality(self, rule: Rule, dataframe: pd.DataFrame) -> Union[bool, int]:
         return dataframe.loc[:, rule.column].nunique() == rule.value
 
@@ -76,6 +76,11 @@ class Compute:
 
     def is_contained_in(self, rule: Rule, dataframe: pd.DataFrame) -> Union[bool, int]:
         return dataframe.loc[:, rule.column].isin(rule.value).astype(int).sum()
+
+    def not_contained_in(self, rule: Rule, dataframe: pd.DataFrame) -> Union[bool, int]:
+        return (
+            (dataframe.loc[:, rule.column].isin(rule.value) == False).astype(int).sum()
+        )
 
     def has_percentile(self, rule: Rule, dataframe: pd.DataFrame) -> Union[bool, int]:
         return (

--- a/cuallee/polars_validation.py
+++ b/cuallee/polars_validation.py
@@ -145,7 +145,7 @@ class Compute:
         return Compute._result(
             dataframe.select(pl.col(rule.column).sum() == rule.value).to_series()
         )
-    
+
     def has_cardinality(self, rule: Rule, dataframe: pl.DataFrame) -> Union[bool, int]:
         """Validate sum value on column"""
         return Compute._result(
@@ -165,6 +165,14 @@ class Compute:
         """Validate set inclusion"""
         return Compute._result(
             dataframe.select(pl.col(rule.column).is_in(rule.value).cast(pl.Int8)).sum()
+        )
+
+    def not_contained_in(self, rule: Rule, dataframe: pl.DataFrame) -> Union[bool, int]:
+        """Validate absence of values in set"""
+        return Compute._result(
+            dataframe.select(
+                pl.col(rule.column).is_not_in(rule.value).cast(pl.Int8)
+            ).sum()
         )
 
     def has_percentile(self, rule: Rule, dataframe: pl.DataFrame) -> Union[bool, int]:

--- a/cuallee/pyspark_validation.py
+++ b/cuallee/pyspark_validation.py
@@ -214,7 +214,7 @@ class Compute(ComputeEngine):
             ComputeMethod.OBSERVE,
         )
         return self.compute_instruction
-    
+
     def has_cardinality(self, rule: Rule):
         """Validation of a column’s different values"""
         predicate = None
@@ -238,6 +238,16 @@ class Compute(ComputeEngine):
     def is_contained_in(self, rule: Rule):  # To Do with Predicate
         """Validation of column value in set of given values"""
         predicate = F.col(f"`{rule.column}`").isin(list(rule.value))
+        self.compute_instruction = ComputeInstruction(
+            predicate,
+            F.sum(predicate.cast(T.LongType())),
+            ComputeMethod.OBSERVE,
+        )
+        return self.compute_instruction
+
+    def not_contained_in(self, rule: Rule):
+        """Validation of column value not in set of given values"""
+        predicate = ~F.col(f"`{rule.column}`").isin(list(rule.value))
         self.compute_instruction = ComputeInstruction(
             predicate,
             F.sum(predicate.cast(T.LongType())),

--- a/cuallee/snowpark_validation.py
+++ b/cuallee/snowpark_validation.py
@@ -216,7 +216,7 @@ class Compute:
             ComputeMethod.SELECT,
         )
         return self.compute_instruction
-    
+
     def has_cardinality(self, rule: Rule):
         """Validation of a column’s distinct values"""
         predicate = None
@@ -243,6 +243,18 @@ class Compute:
         self.compute_instruction = ComputeInstruction(
             predicate,
             F.sum(predicate.cast(T.LongType())),
+            ComputeMethod.SELECT,
+        )
+        return self.compute_instruction
+
+    def not_contained_in(self, rule: Rule):
+        """
+        Validates that each value in the specified column does not exist in the provided set of values.
+        """
+        predicate = ~F.col(rule.column).isin(list(rule.value))
+        self.compute_instruction = ComputeInstruction(
+            predicate,
+            F.sum(predicate.cast(T.IntegerType())),
             ComputeMethod.SELECT,
         )
         return self.compute_instruction

--- a/test/unit/bigquery/test_not_contained_in.py
+++ b/test/unit/bigquery/test_not_contained_in.py
@@ -1,0 +1,145 @@
+import pytest
+import pandas as pd
+
+from google.cloud import bigquery
+
+from cuallee import Check, CheckLevel
+
+
+def teste_negative():
+    df = bigquery.dataset.Table("bigquery-public-data.chicago_taxi_trips.taxi_trips")
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in(
+        "payment_type",
+        (
+            "Way2ride",
+            "Prcard",
+            "Split",
+            "Cash",
+            "Credit Card",
+            "Unknown",
+            "Mobile",
+            "No Charge",
+            "Dispute",
+            "Pcard",
+            "Prepaid",
+        ),
+    )
+    rs = check.validate(df)
+    assert rs.status.str.match("PASS")[1]
+    assert rs.violations[1] == 0
+    assert rs.pass_rate[1] == 1.0
+
+
+def test_positive():
+    df = bigquery.dataset.Table("bigquery-public-data.chicago_taxi_trips.taxi_trips")
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("payment_type", ("Cash", "Credit Card", "Prepaid"))
+    rs = check.validate(df)
+    assert rs.status.str.match("FAIL")[1]
+    assert rs.violations[1] >= 6649036
+    assert rs.pass_threshold[1] == 1.0
+    assert rs.pass_rate[1] <= 202848452 / 208943621
+
+
+@pytest.mark.parametrize(
+    "column_name, rule_value",
+    [
+        [
+            "payment_type",
+            tuple(
+                [
+                    "Way2ride",
+                    "Prcard",
+                    "Split",
+                    "Cash",
+                    "Credit Card",
+                    "Unknown",
+                    "Mobile",
+                    "No Charge",
+                    "Dispute",
+                    "Pcard",
+                    "Prepaid",
+                ]
+            ),
+        ],
+        [
+            "payment_type",
+            list(
+                [
+                    "Way2ride",
+                    "Prcard",
+                    "Split",
+                    "Cash",
+                    "Credit Card",
+                    "Unknown",
+                    "Mobile",
+                    "No Charge",
+                    "Dispute",
+                    "Pcard",
+                    "Prepaid",
+                ]
+            ),
+        ],
+        # [
+        #     "pickup_community_area",
+        #     [i for i in range(1,78)]
+        # ],
+        # [
+        #     [[1, 10], [2, 15], [3, 17]],
+        #     ["id", "test_col"],
+        #     (float(10.0), float(15.0), float(17.0)),
+        # ],
+        # [
+        #     [[1, float(10)], [2, float(15)], [3, float(17)]],
+        #     ["id", "test_col"],
+        #     (10, 15, 17),
+        # ],
+        # [
+        #     [[1, date(2022, 10, 1)], [2, date(2022, 10, 2)], [3, date(2022, 10, 3)]],
+        #     ["id", "test_col"],
+        #     (date(2022, 10, 1), date(2022, 10, 2), date(2022, 10, 3)),
+        # ],
+        # [
+        #     [
+        #         [1, datetime(2022, 10, 1, 10, 0, 0)],
+        #         [2, datetime(2022, 10, 1, 11, 0, 0)],
+        #         [3, datetime(2022, 10, 1, 12, 0, 0)],
+        #     ],
+        #     ["id", "test_col"],
+        #     (
+        #         datetime(2022, 10, 1, 10, 0, 0),
+        #         datetime(2022, 10, 1, 11, 0, 0),
+        #         datetime(2022, 10, 1, 12, 0, 0),
+        #     ),
+        # ],
+    ],
+    ids=(
+        "tuple",
+        "list",
+        # "value_int",
+        # "value_float",
+        # "data_float",
+        # "date",
+        # "timestamp",
+    ),
+)
+def test_parameters(column_name, rule_value):
+    df = bigquery.dataset.Table("bigquery-public-data.chicago_taxi_trips.taxi_trips")
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in(column_name, rule_value)
+    rs = check.validate(df)
+    assert rs.status.str.match("PASS")[1]
+    assert rs.violations[1] == 0
+    assert rs.pass_rate[1] == 1.0
+
+
+def test_coverage():
+    df = bigquery.dataset.Table("bigquery-public-data.chicago_taxi_trips.taxi_trips")
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("payment_type", ("Cash", "Credit Card", "Prepaid"), 0.7)
+    rs = check.validate(df)
+    assert rs.status.str.match("PASS")[1]
+    assert rs.violations[1] >= 6649036
+    assert rs.pass_threshold[1] == 0.7
+    assert rs.pass_rate[1] <= 202848452 / 208943621

--- a/test/unit/duckdb_dataframe/test_not_contained_in.py
+++ b/test/unit/duckdb_dataframe/test_not_contained_in.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from cuallee import Check
+import pytest
+import duckdb
+
+
+def test_negative(check: Check, db: duckdb.DuckDBPyConnection):
+    check.not_contained_in("id", [0, 1, 2, 3, 4, 5])
+    df = pd.DataFrame({"id": range(5)})
+    check.table_name = "df"
+    assert check.validate(db).status.str.match("PASS").all()
+
+
+def test_positive(check: Check, db: duckdb.DuckDBPyConnection):
+    check.not_contained_in("id", [0, 1, 2, 3])
+    df = pd.DataFrame({"id": range(10)})
+    check.table_name = "df"
+    assert check.validate(db).status.str.match("FAIL").all()
+
+
+def test_coverage(check: Check, db: duckdb.DuckDBPyConnection):
+    check.not_contained_in(
+        "id",
+        [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ],
+        0.50,
+    )
+    df = pd.DataFrame({"id": range(10)})
+    check.table_name = "df"
+    result = check.validate(db)
+    assert result.status.str.match("PASS").all()
+    assert result.pass_rate.max() == 0.5

--- a/test/unit/pandas_dataframe/test_not_contained_in.py
+++ b/test/unit/pandas_dataframe/test_not_contained_in.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from cuallee import Check
+import pytest
+
+
+def test_negative(check: Check):
+    check.not_contained_in("id", [0, 1, 2, 3, 4, 5])
+    df = pd.DataFrame({"id": range(5)})
+    assert check.validate(df).status.str.match("PASS").all()
+
+
+def test_positive(check: Check):
+    check.not_contained_in("id", [0, 1, 2, 3])
+    df = pd.DataFrame({"id": range(10)})
+    assert check.validate(df).status.str.match("FAIL").all()
+
+
+def test_coverage(check: Check):
+    check.not_contained_in(
+        "id",
+        [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ],
+        0.50,
+    )
+    df = pd.DataFrame({"id": range(10)})
+    result = check.validate(df)
+    assert result.status.str.match("PASS").all()
+    assert result.pass_rate.max() == 0.5

--- a/test/unit/polars_dataframe/test_not_contained_in.py
+++ b/test/unit/polars_dataframe/test_not_contained_in.py
@@ -1,0 +1,35 @@
+import polars as pl
+from cuallee import Check
+import pytest
+
+
+def test_negative(check: Check):
+    check.not_contained_in("id", [0, 1, 2, 3, 4, 5])
+    df = pl.DataFrame({"id": range(5)})
+    result = check.validate(df).select(pl.col("status")) == "PASS"
+    assert all(result.to_series().to_list())
+
+
+def test_positive(check: Check):
+    check.not_contained_in("id", [0, 1, 2, 3])
+    df = pl.DataFrame({"id": range(10)})
+    result = check.validate(df).select(pl.col("status")) == "FAIL"
+    assert all(result.to_series().to_list())
+
+
+def test_coverage(check: Check):
+    check.not_contained_in(
+        "id",
+        [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ],
+        0.50,
+    )
+    df = pl.DataFrame({"id": range(10)})
+    result = check.validate(df)
+    result = check.validate(df).select(pl.col("status")) == "PASS"
+    assert all(result.to_series().to_list())

--- a/test/unit/pyspark_dataframe/test_not_contained_in.py
+++ b/test/unit/pyspark_dataframe/test_not_contained_in.py
@@ -1,0 +1,103 @@
+import pytest
+
+from datetime import datetime, date
+from cuallee import Check, CheckLevel
+
+
+def test_negative(spark):
+    df = spark.createDataFrame([[1, "blue"], [2, "green"], [3, "grey"]], ["id", "desc"])
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("desc", ("blue", "red", "green", "grey", "black"))
+    rs = check.validate(df)
+    assert rs.first().status == "PASS"
+    assert rs.first().violations == 0
+    assert rs.first().pass_threshold == 1.0
+
+
+def test_positive(spark):
+    df = spark.createDataFrame([[1, "blue"], [2, "green"], [3, "grey"]], ["id", "desc"])
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("desc", ("blue", "red"))
+    rs = check.validate(df)
+    assert rs.first().status == "FAIL"
+    assert rs.first().violations == 2
+    assert rs.first().pass_threshold == 1.0
+    assert rs.first().pass_rate == 1 / 3
+
+
+@pytest.mark.parametrize(
+    "data, columns, rule_value",
+    [
+        [
+            [[1, "blue"], [2, "green"], [3, "grey"]],
+            ["id", "test_col"],
+            tuple(["blue", "green", "grey"]),
+        ],
+        [
+            [[1, "blue"], [2, "green"], [3, "grey"]],
+            ["id", "test_col"],
+            list(["blue", "green", "grey"]),
+        ],
+        [[[1, 10], [2, 15], [3, 17]], ["id", "test_col"], (10, 15, 17)],
+        [
+            [[1, 10], [2, 15], [3, 17]],
+            ["id", "test_col"],
+            (float(10.0), float(15.0), float(17.0)),
+        ],
+        [
+            [[1, float(10)], [2, float(15)], [3, float(17)]],
+            ["id", "test_col"],
+            (10, 15, 17),
+        ],
+        [
+            [[1, date(2022, 10, 1)], [2, date(2022, 10, 2)], [3, date(2022, 10, 3)]],
+            ["id", "test_col"],
+            (date(2022, 10, 1), date(2022, 10, 2), date(2022, 10, 3)),
+        ],
+        [
+            [
+                [1, datetime(2022, 10, 1, 10, 0, 0)],
+                [2, datetime(2022, 10, 1, 11, 0, 0)],
+                [3, datetime(2022, 10, 1, 12, 0, 0)],
+            ],
+            ["id", "test_col"],
+            (
+                datetime(2022, 10, 1, 10, 0, 0),
+                datetime(2022, 10, 1, 11, 0, 0),
+                datetime(2022, 10, 1, 12, 0, 0),
+            ),
+        ],
+    ],
+    ids=(
+        "tuple",
+        "list",
+        "value_int",
+        "value_float",
+        "data_float",
+        "date",
+        "timestamp",
+    ),
+)
+def test_parameters(spark, data, columns, rule_value):
+    df = spark.createDataFrame(data, columns)
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("test_col", rule_value)
+    rs = check.validate(df)
+    assert rs.first().status == "PASS"
+
+
+def test_coverage(spark):
+    df = spark.createDataFrame([[1, "blue"], [2, "green"], [3, "red"]], ["id", "desc"])
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("desc", ("blue", "red"), 0.5)
+    rs = check.validate(df)
+    assert rs.first().status == "PASS"
+    assert rs.first().violations == 1
+    assert rs.first().pass_threshold == 0.5
+    assert rs.first().pass_rate == 2 / 3
+
+
+def test_value_error():
+    check = Check(CheckLevel.WARNING, "pytest")
+    with pytest.raises(ValueError, match="Data types in rule values are inconsistent"):
+        check.not_contained_in("VALUE", (10, "17"))

--- a/test/unit/snowpark_dataframe/test_not_contained_in.py
+++ b/test/unit/snowpark_dataframe/test_not_contained_in.py
@@ -1,0 +1,109 @@
+import pytest
+
+from datetime import datetime, date
+from cuallee import Check, CheckLevel
+
+
+def test_negative(snowpark):
+    df = snowpark.createDataFrame(
+        [[1, "blue"], [2, "green"], [3, "grey"]], ["id", "desc"]
+    )
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("DESC", ("blue", "red", "green", "grey", "black"))
+    rs = check.validate(df)
+    assert rs.first().STATUS == "PASS"
+    assert rs.first().VIOLATIONS == 0
+    assert rs.first().PASS_THRESHOLD == 1.0
+
+
+def test_positive(snowpark):
+    df = snowpark.createDataFrame(
+        [[1, "blue"], [2, "green"], [3, "grey"]], ["id", "desc"]
+    )
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("DESC", ("blue", "red"))
+    rs = check.validate(df)
+    assert rs.first().STATUS == "FAIL"
+    assert rs.first().VIOLATIONS == 2
+    assert rs.first().PASS_THRESHOLD == 1.0
+    assert rs.first().PASS_RATE == 1 / 3
+
+
+@pytest.mark.parametrize(
+    "data, columns, rule_value",
+    [
+        [
+            [[1, "blue"], [2, "green"], [3, "grey"]],
+            ["id", "test_col"],
+            tuple(["blue", "green", "grey"]),
+        ],
+        [
+            [[1, "blue"], [2, "green"], [3, "grey"]],
+            ["id", "test_col"],
+            list(["blue", "green", "grey"]),
+        ],
+        [[[1, 10], [2, 15], [3, 17]], ["id", "test_col"], (10, 15, 17)],
+        [
+            [[1, 10], [2, 15], [3, 17]],
+            ["id", "test_col"],
+            (float(10.0), float(15.0), float(17.0)),
+        ],
+        [
+            [[1, float(10)], [2, float(15)], [3, float(17)]],
+            ["id", "test_col"],
+            (10, 15, 17),
+        ],
+        [
+            [[1, date(2022, 10, 1)], [2, date(2022, 10, 2)], [3, date(2022, 10, 3)]],
+            ["id", "test_col"],
+            (date(2022, 10, 1), date(2022, 10, 2), date(2022, 10, 3)),
+        ],
+        [
+            [
+                [1, datetime(2022, 10, 1, 10, 0, 0)],
+                [2, datetime(2022, 10, 1, 11, 0, 0)],
+                [3, datetime(2022, 10, 1, 12, 0, 0)],
+            ],
+            ["id", "test_col"],
+            (
+                datetime(2022, 10, 1, 10, 0, 0),
+                datetime(2022, 10, 1, 11, 0, 0),
+                datetime(2022, 10, 1, 12, 0, 0),
+            ),
+        ],
+    ],
+    ids=(
+        "tuple",
+        "list",
+        "value_int",
+        "value_float",
+        "data_float",
+        "date",
+        "timestamp",
+    ),
+)
+def test_parameters(snowpark, data, columns, rule_value):
+    df = snowpark.createDataFrame(data, columns)
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("TEST_COL", rule_value)
+    rs = check.validate(df)
+    assert rs.first().STATUS == "PASS"
+
+
+def test_coverage(snowpark):
+    df = snowpark.createDataFrame(
+        [[1, "blue"], [2, "green"], [3, "red"]], ["id", "desc"]
+    )
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.not_contained_in("DESC", ("blue", "red"), 0.5)
+    rs = check.validate(df)
+    assert rs.first().STATUS == "PASS"
+    assert rs.first().VIOLATIONS == 1
+    assert rs.first().PASS_THRESHOLD == 0.5
+    assert rs.first().PASS_RATE == 2 / 3
+
+
+def test_value_error():
+    check = Check(CheckLevel.WARNING, "pytest")
+    with pytest.raises(ValueError, match="Data types in rule values are inconsistent"):
+        check.not_contained_in("VALUE", (10, "17"))


### PR DESCRIPTION
## cuallee
- [x] pyspark
- [x] snowpark
- [x] pandas
- [x] duckdb
- [x] polars
- [x] unit test
- [ ] docs
- [ ] other

**Description:**
This pull request enhances the validation capabilities of Cuallee by introducing the `not_contained_in` function along with its alias `not_in`. These additions allow users to perform validation checks to ensure that specified elements are not present in the target dataset columns or values.

**Details:**
- **Functionality Expansion:** The `not_contained_in` function facilitates the verification that certain elements are absent from the specified dataset column or set of values. This is particularly useful for scenarios where the absence of specific elements is a critical requirement.
- **Alias Convenience:** To enhance user convenience and readability, the alias `not_in` is introduced as an alternative to `not_contained_in`. Users can use either of these aliases interchangeably to perform the same validation check.
- **Improved Validation Scope:** With these additions, Cuallee becomes more versatile in handling a wider range of validation scenarios, including ensuring the absence of particular values or elements within datasets.

**Impact:**
- **Increased Flexibility:** Users can now leverage the `not_contained_in` function and `not_in` alias to perform comprehensive validation checks, thereby enhancing the overall flexibility of Cuallee.
- **Streamlined Validation Process:** The addition of these functions streamlines the validation process by offering a clear and concise method to verify the absence of specific elements within datasets.