### PR TITLE
Replaced a deprecated horizontal sum operation with sum_horizontal for Polars

### DIFF
--- a/cuallee/polars_validation.py
+++ b/cuallee/polars_validation.py
@@ -38,7 +38,7 @@ class Compute:
         return Compute._result(
             dataframe.select(
                 [pl.col(c).is_not_null().cast(pl.Int8).sum() for c in rule.column]
-            ).sum(axis=1)
+            ).sum_horizontal()
             / len(rule.column)
         )
 
@@ -53,7 +53,7 @@ class Compute:
         return Compute._result(
             dataframe.select(
                 [pl.col(c).is_unique().cast(pl.Int8).sum() for c in rule.column]
-            ).sum(axis=1)
+            ).sum_horizontal()
             / len(rule.column)
         )
 


### PR DESCRIPTION
## cuallee
There were two places where sum(axis=1) was used, but since it's deprecated, we should use sum_horizontal instead. 
- [ ] pyspark
- [ ] snowpark
- [ ] pandas
- [ ] duckdb
- [x] polars
- [ ] unit test
- [ ] docs
- [ ] other

## Unit Test
The following unit tests ran successfully
- [x] pytest test/unit/polars_dataframe
- [x] pytest test/unit/polars_dataframe/test_are_complete.py
- [x] pytest test/unit/polars_dataframe/test_are_unique.py
