### PR TITLE
Enable checks on PySpark dataframes with more rows than IntegerType allows

### DIFF
--- a/cuallee/pyspark_validation.py
+++ b/cuallee/pyspark_validation.py
@@ -855,7 +855,7 @@ def summary(check: Check, dataframe: DataFrame) -> DataFrame:
             )
             for rule in check.rules
         ],
-        schema="id int, timestamp string, check string, level string, column string, rule string, value string, rows int, violations int, pass_rate double, pass_threshold double, status string",
+        schema="id int, timestamp string, check string, level string, column string, rule string, value string, rows bigint, violations bigint, pass_rate double, pass_threshold double, status string",
     )
 
     return result

--- a/test/unit/pyspark_dataframe/test_spark_validation.py
+++ b/test/unit/pyspark_dataframe/test_spark_validation.py
@@ -201,6 +201,14 @@ def test_timestamp_column_validation(spark):
         PSV.validate_data_types(check.rules, df)
 
 
+def test_bigint_rows(spark):
+    df = spark.range(2_500_000_000) # beyond 32-bit integer limit
+    check = Check(CheckLevel.WARNING, "pytest")
+    check.is_complete("id")
+    rs = check.validate(df)
+    assert rs.first().status == "PASS"
+
+
 def test_get_compute_dictionary(spark):
     df = spark.range(10)
     check = (


### PR DESCRIPTION
## cuallee
- [x] pyspark
- [ ] snowpark
- [ ] pandas
- [ ] duckdb
- [ ] polars
- [x] unit test
- [ ] docs
- [ ] other

## Issue this solves

`cuallee` returns the number of rows and violations for each check. For PySpark dataframes, it attempts to coerce these values to an [IntegerType](https://spark.apache.org/docs/latest/sql-ref-datatypes.html), which is limited to the 4-byte signed space. If the number of rows exceeds that space, it throws an error, which can be replicated by rolling this branch back to commit d9e3c4c0ebf75f86a14fd1cbc83fc1fd85263420 and running `pytest test/unit/pyspark_dataframe/test_spark_validation.py`, which yields:
```
FAILED test/unit/pyspark_dataframe/test_is_complete.py::test_bigint - pyspark.errors.exceptions.base.PySparkValueError: [VALUE_OUT_OF_BOUND] Value for `obj` must be greater than 2147483647 or less than -2147483648, got 2500000000
```

## The fix

This PR changes the schema returned by validate so that the rows and violations are LongType/bigint, increasing the row limit to 9,223,372,036,854,775,807. It also adds a test to validate that a dataframe with a row count exceeding the IntegerType limit can be checked.