### PR TITLE
Bump Python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 license = {file = "LICENSE"}
 description = "Python library for data validation on DataFrame APIs including Snowflake/Snowpark, Apache/PySpark and Pandas/DataFrame."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## cuallee
- [ ] pyspark
- [ ] snowpark
- [ ] pandas
- [ ] duckdb
- [ ] polars
- [ ] unit test
- [ ] docs
- [x] other

Python 3.9 and below fail to import cuallee due to the case match syntax on [cuallee/__init__.py:L1528](https://github.com/canimus/cuallee/blob/main/cuallee/__init__.py#L1258-L1274)

This PR bumps the compatible Python version.